### PR TITLE
Preserve trailing comma in EXTINF directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,15 +37,20 @@ function m3u (playlist) {
 function transform (line) {
   var splitted = split(line)
   var obj = {}
+  var directive = normalize(splitted[0])
 
-  obj[normalize(splitted[0])] = splitted.length > 1
-    ? parseParams(splitted[1])
+  obj[directive] = splitted.length > 1
+    ? parseParams(directive, splitted[1])
     : void 0
 
   return obj
 }
 
-function parseParams (line) {
+function parseParams (directive, line) {
+  if (directive === 'EXTINF') {
+    return line
+  }
+
   var pairs = filter(line.split(NON_QUOTED_COMMA))
   var attrs = {}
 

--- a/test.js
+++ b/test.js
@@ -43,7 +43,8 @@ const template = [
   },
   'http://2.example.com/index.m3u8',
   { 'PLAYLIST-TYPE': 'VOD' },
-  { 'EXTINF': '10' }
+  { 'EXTINF': '10' },
+  { 'EXTINF': '10,' }
 ]
 
 test('m3u8', t => {

--- a/test.m3u8
+++ b/test.m3u8
@@ -8,4 +8,5 @@ http://1.example.com/index.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1760000,RESOLUTION=1280x720,VIDEO="high",CODECS="avc1.42C01E,mp4a.40.2"
 http://2.example.com/index.m3u8
 #EXT-X-PLAYLIST-TYPE:VOD
+#EXTINF:10
 #EXTINF:10,


### PR DESCRIPTION
The parser should preserve trailing commas in EXTINF directives.
According to 4.3.2.1 of the HLS spec, the comma is required as the
EXTINF format is specified as:

    #EXTINF:<duration>,[<title>]

To preserve this, the EXTINF parameters are always returned as a
string. They are not attempted to be parsed as an attribute list.
This allows source playlists with trailing commas to preserve them
during parsing, and vice-versa.