### PR TITLE
🔧 Fixed an issue where some m3u files could not be recognized correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function parseParams (line) {
       return kvList[0]
     }
 
-    attrs[ trim(kvList[0]) ] = kvList.length > 1
+    attrs[trim(kvList[0])] = kvList.length > 1
       ? trim(kvList[1])
       : void 0
   }
@@ -77,7 +77,7 @@ function normalize (key) {
 
 function split (line) {
   var pos = line.indexOf(':')
-  return pos > 0 ? [ line.slice(0, pos), line.slice(pos + 1) ] : [line]
+  return pos > 0 ? [line.slice(0, pos), line.slice(pos + 1)] : [line]
 }
 
 function startsWith (s, prefix) {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = m3u
 function m3u (playlist) {
   var lines = playlist.toString().split('\n')
 
-  if (!lines.length || !startsWith(lines[0], '#EXTM3U')) {
+  if (!lines.length || !startsWith(lines[0].trim(), '#EXTM3U')) {
     throw new Error('Invalid m3u playlist')
   }
 

--- a/test.js
+++ b/test.js
@@ -7,8 +7,8 @@ import test from 'ava'
 const playlist = fs.readFileSync('test.m3u8', 'utf8')
 
 const template = [
-  {STATUS: void 0},
-  {'ID3-EQUIV-TDTG': '2015-01-01T01:21:00'},
+  { STATUS: void 0 },
+  { 'ID3-EQUIV-TDTG': '2015-01-01T01:21:00' },
   { MEDIA: {
     TYPE: 'VIDEO',
     'GROUP-ID': 'chunked',
@@ -43,7 +43,7 @@ const template = [
   },
   'http://2.example.com/index.m3u8',
   { 'PLAYLIST-TYPE': 'VOD' },
-  { 'EXTINF': '10' }
+  { EXTINF: '10' }
 ]
 
 test('m3u8', t => {


### PR DESCRIPTION
The first line of some m3u files have **whitespace characters**, so the `String.prototype.startsWith()` method can't recognize it correctly. The string `'#EXTM3U'` should compare with a string which has been removed the leading whitespace characters.